### PR TITLE
Custom properties as color config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.2] - 2019-08-20
 ### Changed
 - Allow HEX values for color config
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Allow CSS custom properties for color config
 
 ## [0.3.2] - 2019-08-20
 ### Changed

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ module.exports = {
 
 Config object accepts the following properties:
 
-* `color` changes the default box-shadow base color and accepts an RGB (e.g. `'77,192,181'`) or HEX triplet (e.g. `'#4dc0b5'`) as its value
+* `color` changes the default box-shadow base color and accepts an RGB (e.g. `'77,192,181'`) or HEX triplet (e.g. `'#4dc0b5'`) as its value. When using a CSS custom property (variable) as the value, you have to use an RGB triplet.
 * `opacityBoost` is added to the default box-shadow opacity and accepts a number between 0.0 and 1.0
 
 ## Basic usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwindcss-elevation",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Tailwind CSS plugin for Material Components elevation classes.",
   "author": "Joonas Kykkänen <jonaskay@iki.fi>",
   "repository": "https://github.com/jonaskay/tailwindcss-elevation.git",

--- a/src/regex.js
+++ b/src/regex.js
@@ -1,4 +1,5 @@
 module.exports = {
+  customProperty: 'var([^)]+)',
   hex: '#[A-Fa-f0-9]+',
   rgb: '\\s*\\d+\\s*\\,\\s*\\d+\\s*\\,\\s*\\d+\\s*',
 };

--- a/src/validateConfig.js
+++ b/src/validateConfig.js
@@ -5,7 +5,7 @@ function validateColor(color) {
     return null;
   }
 
-  const re = new RegExp(`${regex.rgb}|${regex.hex}`);
+  const re = new RegExp(`${regex.rgb}|${regex.hex}|${regex.customProperty}`);
   if (re.test(color)) {
     return null;
   } else {

--- a/test/fixtures/varColorConfig.js
+++ b/test/fixtures/varColorConfig.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [require('../../index')([], { color: 'var(--color)' })],
+};

--- a/test/tailwindBuild.js
+++ b/test/tailwindBuild.js
@@ -93,6 +93,18 @@ describe('tailwind', function() {
       });
     });
 
+    it('should generate CSS file with utilities when base color is defined using a custom property', async function() {
+      await buildCSSFile('./test/fixtures/varColorConfig.js');
+
+      const regexps = [
+        /.elevation-0\s+{/g,
+        /box-shadow: 0px 0px 0px 0px rgba\(var\(--color\),0.20\), 0px 0px 0px 0px rgba\(var\(--color\),0.14\), 0px 0px 0px 0px rgba\(var\(--color\),0.12\);\s+/g,
+      ];
+      regexps.forEach(function(regexp) {
+        assert.fileContentMatch(output, regexp);
+      });
+    });
+
     it('should generate CSS file with utilities when opacity boost is defined', async function() {
       await buildCSSFile('./test/fixtures/opacityConfig.js');
 

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -35,6 +35,15 @@ describe('#utilities()', function() {
     );
   });
 
+  it('should return a utility for .elevation-1 when config includes color with a custom property', function() {
+    const config = { color: 'var(--blue)' };
+
+    assert.equal(
+      utilities(config)['.elevation-1'].boxShadow,
+      '0px 2px 1px -1px rgba(var(--blue),0.20), 0px 1px 1px 0px rgba(var(--blue),0.14), 0px 1px 3px 0px rgba(var(--blue),0.12)'
+    );
+  });
+
   it('should return a utility for .elevation-2 when config includes opacityBoost', function() {
     const config = { opacityBoost: '.23' };
     assert.equal(

--- a/test/validateConfig.js
+++ b/test/validateConfig.js
@@ -4,7 +4,16 @@ const validateConfig = require('../src/validateConfig');
 
 describe('#validateConfig()', function() {
   it('should return an error message if color is invalid', function() {
-    const colors = ['red', '1', '255,0', '-1,-2,-3', '4fd1c5', '#...'];
+    const colors = [
+      'red',
+      '1',
+      '255,0',
+      '-1,-2,-3',
+      '4fd1c5',
+      '#...',
+      'var',
+      '(--foo)',
+    ];
     colors.forEach(function(color) {
       assert.equal(
         validateConfig({ color: color }).message,
@@ -14,7 +23,14 @@ describe('#validateConfig()', function() {
   });
 
   it('should return null if color is valid', function() {
-    const colors = ['0, 0, 0', ' 1,2,3 ', '255,255,255', '#4fd1c5', '#FFF'];
+    const colors = [
+      '0, 0, 0',
+      ' 1,2,3 ',
+      '255,255,255',
+      '#4fd1c5',
+      '#FFF',
+      'var(--foo)',
+    ];
     colors.forEach(function(color) {
       assert.isNull(validateConfig({ color: color }));
     });


### PR DESCRIPTION
Users should be able to define an RGB triplet inside a CSS custom property and then use it inside the color config.